### PR TITLE
patch01: address path-based groupmint

### DIFF
--- a/reviews/202407-gnosis/01-report.md
+++ b/reviews/202407-gnosis/01-report.md
@@ -1,0 +1,5 @@
+# External review of v0.3.4-alpha
+
+Report done by internal Gnosis review team.
+
+https://gnosischain.notion.site/CirclesV2-Audit-2f846eba6e2c4540a256f518506428ad

--- a/reviews/202407-gnosis/02-reply.md
+++ b/reviews/202407-gnosis/02-reply.md
@@ -1,0 +1,16 @@
+# Addressing review comments
+
+## Attacker can steal tokens from user who opted out consented flow
+
+### Summary
+
+If any user opts out of consented flow by calling `setAdvancedUsageFlag()` with argument `ADVANCED_FLAG_OPTOUT_CONSENTEDFLOW` they accept that parties they do not trust may hold their tokens due to their tokens being used as a transition in a flow matrix. Due to the way group tokens are minted when operating a flow matrix, any group can steal every tokens held by a user. Without consented flow, an attacker can deploy a group and steal tokens from the user without requiring the trust of the user.
+
+(for full description, see report)
+
+### Response strategy:
+1. consider only consented flow, ie. remove ability to opt-out. Even if 3. is adopted as the elegant fix for netting the flow matrix correctly over group mints, it still leaves open the first premise of the severe attack: "Attacker can steal tokens from user who opted out consented flow", which matters once different Circles identifiers have market price valuations.
+2. consider requiring the flow operator must be authorised for all touched vertices:
+    - (re)imposing this restriction makes it a lot harder to iterate on improvements for flow operators;
+    - on the other hand, enabling it would be a strong mechanism against yet unknown exploits in the protocol. This however needs to be balanced with our confidence in the correctness of the implementation.
+3. consider improving how the flow matrix should be netted over group mints along a flow path to remove the error of nullable path edges.

--- a/src/hub/Hub.sol
+++ b/src/hub/Hub.sol
@@ -782,6 +782,14 @@ contract Hub is Circles, TypeDefinitions, IHubErrors {
         return nettedFlow;
     }
 
+    /**
+     * @dev Effect the flow edges of the path transfer, this will revert if any balance is insufficient
+     * @param _flowVertices an ordered list of avatar addresses as the vertices which the path touches
+     * @param _flow array of flow edges, each edge is a struct with the amount and streamSinkId
+     * @param _streams array of streams, each stream is a struct that references the source vertex coordinate,
+     * the ids of the terminal flow edges of this stream, and the data that is passed to the ERC1155 acceptance check
+     * @param _coordinates unpacked array of coordinates of the flow edges
+     */
     function _effectPathTransfers(
         address[] calldata _flowVertices,
         FlowEdge[] calldata _flow,
@@ -864,6 +872,13 @@ contract Hub is Circles, TypeDefinitions, IHubErrors {
         }
     }
 
+    /**
+     * @dev Call the acceptance checks for the streams, and return the netted streams
+     * @param _flowVertices sorted array of avatar addresses as the vertices which the path touches
+     * @param _flow array of flow edges
+     * @param _streams array of streams
+     * @param _coordinates unpacked array of coordinates of the flow edges
+     */
     function _callAcceptanceChecks(
         address[] calldata _flowVertices,
         FlowEdge[] calldata _flow,


### PR DESCRIPTION
**problem**: for path-based groupmint (much like with external `groupMint`) the minted group tokens were delivered to the sender. In the verification of the flow matrix of a path transfer, this resulted in any groupmint always netting out zero, and as such always being allowed for the maximum balance of the avatar - IF the avatar had opted out of consented flow for any (malicious) group.

**In this patch**, the group tokens that are minted over the path transfer are minted in-place onto the group address - so the path transfer needs to explicitly move the group tokens onward (or the group is set as the final receiver in the stream).

This patch only addresses that now the amount "mintable"/"stealable" is limited to the total capacity of other Circles that the avatar is able to receive from their trusted Circles (in exchange for the tokens minted into the group). So the core problem remains that, without consented flow, or when an avatar opts out from consented flow, an attacker can steal valuable Circles from a user who opts-out of consented flow - albeit at a possibly rate limited flow (which is still unacceptable).

It is important to note that, while this patch by itself alone does not address the attack vector (the main one remains: being able to opt out from consented flow), it is well-worth considering this patch because this implementation fix for path-based group mint is the more logical, and elegant one.