### PR TITLE
Proposal v0.3.6 - patch9(a,b,c)

### DIFF
--- a/src/hub/Hub.sol
+++ b/src/hub/Hub.sol
@@ -27,7 +27,7 @@ contract Hub is Circles, TypeDefinitions, IHubErrors {
     /**
      * @dev Welcome bonus for new avatars invited to Circles. Set to 50 Circles.
      */
-    uint256 private constant WELCOME_BONUS = 50 * EXA;
+    uint256 private constant WELCOME_BONUS = 48 * EXA;
 
     /**
      * @dev The cost of an invitation for a new avatar, paid in personal Circles burnt, set to 100 Circles.

--- a/src/hub/Hub.sol
+++ b/src/hub/Hub.sol
@@ -621,11 +621,11 @@ contract Hub is Circles, TypeDefinitions, IHubErrors {
     }
 
     /**
-     * @notice Returns true if the flow to the receiver is permitted. This function is called only
-     * by the operateFlowMatrix function to check whether the flow edge is permitted.
-     * The receiver must trust the Circles being sent, and the sender must trust the receiver.
-     * Unless the sender avatar concerned has opted out of
-     * consented flow, in which case the flow is permitted once the receiver trusts the Circles.
+     * @notice Returns true if the flow to the receiver is permitted. By default avatars don't have
+     * consented flow enabled, so then this function is equivalent to isTrusted(). This function is called
+     * to check whether the flow edge is permitted (either along a path's flow edge, or upon groupMint).
+     * If the sender avatar has enabled consented flow for the Circles balances they own,
+     * then the receiver must trust the Circles being sent, and the sender must trust the receiver.
      * @param _from Address of the sender
      * @param _to Address of the receiver
      * @param _circlesAvatar Address of the Circles avatar of the Circles being sent

--- a/src/hub/Hub.sol
+++ b/src/hub/Hub.sol
@@ -46,17 +46,17 @@ contract Hub is Circles, TypeDefinitions, IHubErrors {
 
     // State variables
 
-    /**
-     * @notice The global name of Circles.
-     * todo, change this to "Circles" for the production deployment
-     */
-    string public name = "Rings";
+    // /**
+    //  * @notice The global name of Circles.
+    //  * todo, change this to "Circles" for the production deployment
+    //  */
+    // string public name = "Rings";
 
-    /**
-     * @notice The global symbol ticker for Circles.
-     * todo, change this to "CRC" for the production deployment
-     */
-    string public symbol = "RING";
+    // /**
+    //  * @notice The global symbol ticker for Circles.
+    //  * todo, change this to "CRC" for the production deployment
+    //  */
+    // string public symbol = "RING";
 
     /**
      * @notice The Hub v1 contract address.

--- a/src/hub/Hub.sol
+++ b/src/hub/Hub.sol
@@ -46,18 +46,6 @@ contract Hub is Circles, TypeDefinitions, IHubErrors {
 
     // State variables
 
-    // /**
-    //  * @notice The global name of Circles.
-    //  * todo, change this to "Circles" for the production deployment
-    //  */
-    // string public name = "Rings";
-
-    // /**
-    //  * @notice The global symbol ticker for Circles.
-    //  * todo, change this to "CRC" for the production deployment
-    //  */
-    // string public symbol = "RING";
-
     /**
      * @notice The Hub v1 contract address.
      */

--- a/src/hub/Hub.sol
+++ b/src/hub/Hub.sol
@@ -114,7 +114,6 @@ contract Hub is Circles, TypeDefinitions, IHubErrors {
     // Events
 
     event RegisterHuman(address indexed avatar);
-    // event InviteHuman(address indexed inviter, address indexed invited);
     event RegisterOrganization(address indexed organization, string name);
     event RegisterGroup(
         address indexed group, address indexed mint, address indexed treasury, string name, string symbol

--- a/src/hub/Hub.sol
+++ b/src/hub/Hub.sol
@@ -40,9 +40,9 @@ contract Hub is Circles, TypeDefinitions, IHubErrors {
     address private constant SENTINEL = address(0x1);
 
     /**
-     * @dev advanced flag to indicate whether avatar disables consented flow
+     * @dev advanced flag to indicate whether avatar enables consented flow
      */
-    bytes32 private constant ADVANCED_FLAG_DISABLE_CONSENTEDFLOW = bytes32(uint256(1));
+    bytes32 private constant ADVANCED_FLAG_ENABLE_CONSENTEDFLOW = bytes32(uint256(1));
 
     // State variables
 
@@ -646,8 +646,9 @@ contract Hub is Circles, TypeDefinitions, IHubErrors {
     function isPermittedFlow(address _from, address _to, address _circlesAvatar) public view returns (bool) {
         // if receiver does not trust the Circles being sent, then the flow is not permitted regardless
         if (uint256(trustMarkers[_to][_circlesAvatar].expiry) < block.timestamp) return false;
-        // if the advanced usage flag disables consented flow, then the uni-directional trust is sufficient
-        if (advancedUsageFlags[_from] & ADVANCED_FLAG_DISABLE_CONSENTEDFLOW != bytes32(0)) {
+        // if the advanced usage flag does not enables consented flow,
+        // then the uni-directional trust is sufficient, ie. no consented flow applies for sender
+        if (advancedUsageFlags[_from] & ADVANCED_FLAG_ENABLE_CONSENTEDFLOW == bytes32(0)) {
             return true;
         }
         // however, consented flow also requires sender to trust the receiver

--- a/src/hub/Hub.sol
+++ b/src/hub/Hub.sol
@@ -780,7 +780,7 @@ contract Hub is Circles, TypeDefinitions, IHubErrors {
                 int256 flow = int256(uint256(_flow[i].amount));
 
                 // check the receiver trusts the Circles being sent
-                // and that the sender trusts the receiver (unless sender opt-ed out of consented flow)
+                // and if the sender has enabled consented flow, also check that the sender trusts the receiver
                 if (!isPermittedFlow(from, to, circlesId)) {
                     // Flow edge is not permitted.
                     revert CirclesHubFlowEdgeIsNotPermitted(to, toTokenId(circlesId), 1);

--- a/src/names/NameRegistry.sol
+++ b/src/names/NameRegistry.sol
@@ -27,11 +27,6 @@ contract NameRegistry is Base58Converter, INameRegistry, INameRegistryErrors, IC
      */
     string public constant DEFAULT_CIRCLES_SYMBOL = "RING";
 
-    // /**
-    //  * @dev The IPFS protocol prefix for cid v0 resolution
-    //  */
-    // string private constant IPFS_PROTOCOL = "ipfs://Qm";
-
     // State variables
 
     /**


### PR DESCRIPTION
proposal v0.3.6
- consented flow is not enabled by default (due to the intricacies of actually building, this was just a technical requirement to shift the default, but I can also have peace with that default as long as the option to opt-in to a higher standard of protecting your value remains available to users - and without affecting the choice of others.)
- switched to the new model of consented flow MRS-model (as of this morning with the fix), ie. so spend-ability of other owners is not affected by people opting in to MRS
- (explicit groupMint as originally discussed and events improvements to help the indexer and save necessary compile size to make all of this work)
- recursive MRS model implemented to preserve the flow property along the path for those who opted-in