### PR TITLE
(hub): change the invite flow for humans to use trust as extended invitation

### DIFF
--- a/src/operators/SignedPathOperator.sol
+++ b/src/operators/SignedPathOperator.sol
@@ -42,11 +42,4 @@ contract SignedPathOperator is BaseOperator, TypeDefinitions {
         // Call the hub to operate the flow matrix
         hub.operateFlowMatrix(_flowVertices, _flow, _streams, _packedCoordinates);
     }
-
-    // Internal functions
-
-    // function _extractSource(bytes calldata _packedCoordinates, uint256 _sourceIndex) internal pure returns (uint16) {
-    //     return
-    //         uint16(uint8(_packedCoordinates[_sourceIndex])) << 8 | uint16(uint8(_packedCoordinates[_sourceIndex + 1]));
-    // }
 }

--- a/test/hub/V1MintStatusUpdate.t.sol
+++ b/test/hub/V1MintStatusUpdate.t.sol
@@ -64,13 +64,19 @@ contract V1MintStatusUpdateTest is Test, TimeCirclesSetup, HumanRegistration {
         vm.startPrank(addresses[0]);
         tokenAlice.stop();
         assertTrue(tokenAlice.stopped(), "Token not stopped");
-        mockHub.registerHuman(bytes32(0));
+        mockHub.registerHuman(address(0), bytes32(0));
         vm.stopPrank();
         assertTrue(mockHub.isHuman(addresses[0]), "Alice not registered");
 
         // Alice invites Bob, while he is still active in V1
+        // to do that she must trust Bob, and then he can register with Alice as inviter
         vm.prank(addresses[0]);
-        mockHub.inviteHuman(addresses[1]);
+        // Alice trusts Bob
+        mockHub.trust(addresses[1], type(uint96).max);
+        // Bob registers with Alice as inviter
+        vm.prank(addresses[1]);
+        // Bob calls register Human with Alice as inviter
+        mockHub.registerHuman(addresses[0], bytes32(0));
         assertTrue(mockHub.isHuman(addresses[1]), "Bob not registered");
 
         // move time


### PR DESCRIPTION
**motivation**: the invite flow was passive, so an existing DAO or address could be unwantedly be registered as a human by anyone, blocking them from being registering as org or group themselves;

in the new flow the inviter must go ahead and trust the address of whom they want to invite; the invited human can then call register with the address of a human trusting them. The inviter (if multiple the invitee effectively picks one) must pay the invitation cost