### PR TITLE
20241118 docs update beta

### DIFF
--- a/.github/workflows/deploy-mkdocs.yml
+++ b/.github/workflows/deploy-mkdocs.yml
@@ -6,59 +6,91 @@ on:
       - beta
       - candidate/stable
       - testdocs
+      
+permissions:
+  contents: write
+  pages: write
+  id-token: write
 
 jobs:
   deploy:
-    permissions:
-      contents: write      # This allows writing to the repository contents
-      pages: write         # This allows deploying to GitHub Pages
-      id-token: write      # This is required for requesting the JWT
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Set up Conda
-        uses: conda-incubator/setup-miniconda@v2
+      - uses: actions/checkout@v4
         with:
-          auto-update-conda: true
-          python-version: 3.9
-
+          fetch-depth: 1
+          
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+          cache: 'pip'
+          
       - name: Install dependencies
-        shell: bash -l {0}
         run: |
           cd docs/
-          conda install -c conda-forge --file requirements.txt
-
-      - name: Build Beta Docs
+          pip install -r requirements.txt
+          
+      - name: Build Beta Documentation
         run: |
+          git fetch --depth 1 origin beta:beta
           git checkout beta
           cd docs/
           mkdocs build
           mkdir -p ../gh-pages/beta
-          cp -R site/* ../gh-pages/beta
-
-      - name: Build Stable Docs
+          cp -R site/* ../gh-pages/beta/
+          
+      - name: Build Stable Documentation
         run: |
+          git fetch --depth 1 origin candidate/stable:candidate/stable
           git checkout candidate/stable
           cd docs/
           mkdocs build
           mkdir -p ../gh-pages/stable
-          cp -R site/* ../gh-pages/stable
-
+          cp -R site/* ../gh-pages/stable/
+          
       - name: Create Redirect Index
         run: |
-          echo '<!DOCTYPE html>
+          cat > ./gh-pages/index.html << 'EOF'
+          <!DOCTYPE html>
           <html>
-            <head>
-              <meta http-equiv="refresh" content="0; url=beta/" />
-            </head>
-            <body>
+          <head>
+              <title>Documentation Redirect</title>
+              <meta http-equiv="refresh" content="0; url=beta/">
+              <style>
+                  body {
+                      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+                      max-width: 600px;
+                      margin: 50px auto;
+                      text-align: center;
+                      line-height: 1.6;
+                  }
+                  .links {
+                      margin-top: 20px;
+                  }
+                  a {
+                      color: #0366d6;
+                      text-decoration: none;
+                  }
+                  a:hover {
+                      text-decoration: underline;
+                  }
+              </style>
+          </head>
+          <body>
+              <h1>Documentation</h1>
               <p>Redirecting to the latest beta documentation...</p>
-            </body>
-          </html>' > ./gh-pages/index.html
+              <div class="links">
+                  <p>If you are not redirected, please choose a version:</p>
+                  <p><a href="beta/">Beta Documentation</a> | <a href="stable/">Stable Documentation</a></p>
+              </div>
+          </body>
+          </html>
+          EOF
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./gh-pages
+          force_orphan: true

--- a/.github/workflows/deploy-mkdocs.yml
+++ b/.github/workflows/deploy-mkdocs.yml
@@ -3,7 +3,9 @@ name: Deploy MkDocs to GitHub Pages
 on:
   push:
     branches:
-      - v0.3.6-docs
+      - beta
+      - candidate/stable
+      - testdocs
 
 jobs:
   deploy:
@@ -33,8 +35,47 @@ jobs:
           cd docs/
           mkdocs build
 
+      - name: Create Redirect Index
+        run: |
+          echo '<!DOCTYPE html>
+          <html>
+            <head>
+              <meta http-equiv="refresh" content="0; url=beta/" />
+            </head>
+            <body>
+              <p>Redirecting to the latest beta documentation...</p>
+            </body>
+          </html>' > ./docs/site/index.html
+
+      - name: Determine Deployment Directory
+        id: branch
+        run: |
+          if [[ "${GITHUB_REF_NAME}" == "beta" ]]; then
+            echo "DEPLOY_DIR=beta" >> $GITHUB_ENV
+          elif [[ "${GITHUB_REF_NAME}" == "candidate/stable" ]]; then
+            echo "DEPLOY_DIR=candidate" >> $GITHUB_ENV
+          else
+            echo "Unknown branch: ${GITHUB_REF_NAME}" && exit 1
+          fi
+
+      - name: Prepare Deployment Directory
+        run: |
+          mkdir -p ./gh-pages/${{ env.DEPLOY_DIR }}
+          cp -R ./docs/site/* ./gh-pages/${{ env.DEPLOY_DIR }}
+          if [[ "${GITHUB_REF_NAME}" == "beta" ]]; then
+            echo '<!DOCTYPE html>
+            <html>
+              <head>
+                <meta http-equiv="refresh" content="0; url=beta/" />
+              </head>
+              <body>
+                <p>Redirecting to the latest beta documentation...</p>
+              </body>
+            </html>' > ./gh-pages/index.html
+          fi
+
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/site
+          publish_dir: ./gh-pages

--- a/.github/workflows/deploy-mkdocs.yml
+++ b/.github/workflows/deploy-mkdocs.yml
@@ -54,7 +54,7 @@ jobs:
             echo "DEPLOY_DIR=beta" >> $GITHUB_ENV
           elif [[ "${GITHUB_REF_NAME}" == "candidate/stable" ]]; then
             echo "DEPLOY_DIR=candidate" >> $GITHUB_ENV
-          elif [[ "${GITHUB_REF_NAME}" == "testdoc" ]]; then
+          elif [[ "${GITHUB_REF_NAME}" == "testdocs" ]]; then
             echo "DEPLOY_DIR=test" >> $GITHUB_ENV
           else
             echo "Unknown branch: ${GITHUB_REF_NAME}" && exit 1

--- a/.github/workflows/deploy-mkdocs.yml
+++ b/.github/workflows/deploy-mkdocs.yml
@@ -29,11 +29,21 @@ jobs:
           cd docs/
           conda install -c conda-forge --file requirements.txt
 
-      - name: Build site
-        shell: bash -l {0}
+      - name: Build Beta Docs
         run: |
+          git checkout beta
           cd docs/
           mkdocs build
+          mkdir -p ../gh-pages/beta
+          cp -R site/* ../gh-pages/beta
+
+      - name: Build Stable Docs
+        run: |
+          git checkout candidate/stable
+          cd docs/
+          mkdocs build
+          mkdir -p ../gh-pages/stable
+          cp -R site/* ../gh-pages/stable
 
       - name: Create Redirect Index
         run: |
@@ -45,36 +55,7 @@ jobs:
             <body>
               <p>Redirecting to the latest beta documentation...</p>
             </body>
-          </html>' > ./docs/site/index.html
-
-      - name: Determine Deployment Directory
-        id: branch
-        run: |
-          if [[ "${GITHUB_REF_NAME}" == "beta" ]]; then
-            echo "DEPLOY_DIR=beta" >> $GITHUB_ENV
-          elif [[ "${GITHUB_REF_NAME}" == "candidate/stable" ]]; then
-            echo "DEPLOY_DIR=candidate" >> $GITHUB_ENV
-          elif [[ "${GITHUB_REF_NAME}" == "testdocs" ]]; then
-            echo "DEPLOY_DIR=test" >> $GITHUB_ENV
-          else
-            echo "Unknown branch: ${GITHUB_REF_NAME}" && exit 1
-          fi
-
-      - name: Prepare Deployment Directory
-        run: |
-          mkdir -p ./gh-pages/${{ env.DEPLOY_DIR }}
-          cp -R ./docs/site/* ./gh-pages/${{ env.DEPLOY_DIR }}
-          if [[ "${GITHUB_REF_NAME}" == "beta" ]]; then
-            echo '<!DOCTYPE html>
-            <html>
-              <head>
-                <meta http-equiv="refresh" content="0; url=beta/" />
-              </head>
-              <body>
-                <p>Redirecting to the latest beta documentation...</p>
-              </body>
-            </html>' > ./gh-pages/index.html
-          fi
+          </html>' > ./gh-pages/index.html
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/deploy-mkdocs.yml
+++ b/.github/workflows/deploy-mkdocs.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - beta
       - candidate/stable
+      - 20241118-docs-update-beta
       
 permissions:
   contents: write
@@ -39,14 +40,14 @@ jobs:
           mkdir -p ../gh-pages/beta
           cp -R site/* ../gh-pages/beta/
           
-      - name: Build Stable Documentation
+      - name: Build Candidate Stable Documentation
         run: |
           git fetch --depth 1 origin candidate/stable:candidate/stable
           git checkout candidate/stable
           cd docs/
           mkdocs build
-          mkdir -p ../gh-pages/stable
-          cp -R site/* ../gh-pages/stable/
+          mkdir -p ../gh-pages/candidate-stable
+          cp -R site/* ../gh-pages/candidate-stable/
           
       - name: Create Redirect Index
         run: |
@@ -81,7 +82,7 @@ jobs:
               <p>Redirecting to the latest beta documentation...</p>
               <div class="links">
                   <p>If you are not redirected, please choose a version:</p>
-                  <p><a href="beta/">Beta Documentation</a> | <a href="stable/">Stable Documentation</a></p>
+                  <p><a href="beta/">Beta Documentation</a> | <a href="candidate-stable/">Candidate Stable Documentation</a></p>
               </div>
           </body>
           </html>

--- a/.github/workflows/deploy-mkdocs.yml
+++ b/.github/workflows/deploy-mkdocs.yml
@@ -54,6 +54,8 @@ jobs:
             echo "DEPLOY_DIR=beta" >> $GITHUB_ENV
           elif [[ "${GITHUB_REF_NAME}" == "candidate/stable" ]]; then
             echo "DEPLOY_DIR=candidate" >> $GITHUB_ENV
+          elif [[ "${GITHUB_REF_NAME}" == "testdoc" ]]; then
+            echo "DEPLOY_DIR=test" >> $GITHUB_ENV
           else
             echo "Unknown branch: ${GITHUB_REF_NAME}" && exit 1
           fi

--- a/.github/workflows/deploy-mkdocs.yml
+++ b/.github/workflows/deploy-mkdocs.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - beta
       - candidate/stable
-      - testdocs
       
 permissions:
   contents: write


### PR DESCRIPTION
- dropped conda for pip, is already in a VM, much much faster to build
- build both `beta` and `candidate-stable` on each push; but this way we can have both hosted under `/beta` and `candidate-stable`
- introduce a redirection page for original URL which redirects to beta by default
fixes #108 