### PR TITLE
feat(groups): score-gated mint policy

### DIFF
--- a/src/groups/ScoreGatedMintPolicy.sol
+++ b/src/groups/ScoreGatedMintPolicy.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity >=0.8.24;
+
+import "./BaseMintPolicy.sol";
+
+/**
+ * @notice Minimal interface to the off-chain score verifier
+ * (e.g. NewMockScore — sparse Merkle tree of trust scores).
+ *
+ * `verifyScore` is a pure-storage view: given an address, a claimed score
+ * and an SMT proof, it returns true iff the proof reconstructs to the
+ * latest published root.
+ */
+interface IScoreVerifier {
+    function verifyScore(address user, uint256 score, bytes calldata proof) external view returns (bool);
+}
+
+/**
+ * @notice Mint policy gated by an off-chain trust score.
+ *
+ * Mint is allowed iff:
+ *   1. the caller-provided `score` is >= `scoreThreshold`, and
+ *   2. the SMT proof verifies against the latest published root in `verifier`.
+ *
+ * The score and proof are passed through `_data` as
+ * `abi.encode(uint256 score, bytes proof)`. The `_group` argument is ignored
+ * because the current verifier (NewMockScore) is single-group; a future
+ * multi-group verifier would key roots by group inside `verifyScore`.
+ *
+ * Other policy hooks (`beforeRedeemPolicy`, `beforeBurnPolicy`) inherit base
+ * behavior — redeem returns the requested collateral, burn always returns true.
+ */
+contract ScoreGatedMintPolicy is MintPolicy {
+    IScoreVerifier public immutable verifier;
+    uint256 public immutable scoreThreshold;
+
+    error ScoreBelowThreshold(uint256 score, uint256 threshold);
+    error ProofVerificationFailed(address minter, uint256 score);
+
+    constructor(IScoreVerifier _verifier, uint256 _scoreThreshold) {
+        verifier = _verifier;
+        scoreThreshold = _scoreThreshold;
+    }
+
+    function beforeMintPolicy(
+        address _minter,
+        address, /*_group*/
+        uint256[] calldata, /*_collateral*/
+        uint256[] calldata, /*_amounts*/
+        bytes calldata _data
+    ) external view override returns (bool) {
+        (uint256 score, bytes memory proof) = abi.decode(_data, (uint256, bytes));
+        if (score < scoreThreshold) revert ScoreBelowThreshold(score, scoreThreshold);
+        if (!verifier.verifyScore(_minter, score, proof)) revert ProofVerificationFailed(_minter, score);
+        return true;
+    }
+}

--- a/test/groups/ScoreGatedMintPolicy.t.sol
+++ b/test/groups/ScoreGatedMintPolicy.t.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity >=0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import "../../src/groups/ScoreGatedMintPolicy.sol";
+
+/**
+ * @notice Mock verifier — accepts a hardcoded set of (user, score, proof) tuples.
+ * Used to drive the policy without needing a real SMT setup in unit tests.
+ */
+contract MockScoreVerifier is IScoreVerifier {
+    mapping(bytes32 => bool) private _accepted;
+
+    function accept(address user, uint256 score, bytes memory proof) external {
+        _accepted[keccak256(abi.encode(user, score, proof))] = true;
+    }
+
+    function verifyScore(address user, uint256 score, bytes calldata proof) external view returns (bool) {
+        return _accepted[keccak256(abi.encode(user, score, proof))];
+    }
+}
+
+contract ScoreGatedMintPolicyTest is Test {
+    MockScoreVerifier verifier;
+    ScoreGatedMintPolicy policy;
+
+    address constant USER = address(0x1234);
+    address constant GROUP = address(0xabcd);
+    uint256 constant THRESHOLD = 50;
+
+    function setUp() public {
+        verifier = new MockScoreVerifier();
+        policy = new ScoreGatedMintPolicy(IScoreVerifier(address(verifier)), THRESHOLD);
+    }
+
+    function _data(uint256 score, bytes memory proof) internal pure returns (bytes memory) {
+        return abi.encode(score, proof);
+    }
+
+    function _emptyArrays() internal pure returns (uint256[] memory, uint256[] memory) {
+        return (new uint256[](0), new uint256[](0));
+    }
+
+    function testAllowsMintWhenScoreAtThresholdAndProofValid() public {
+        bytes memory proof = hex"deadbeef";
+        verifier.accept(USER, THRESHOLD, proof);
+
+        (uint256[] memory c, uint256[] memory a) = _emptyArrays();
+        bool ok = policy.beforeMintPolicy(USER, GROUP, c, a, _data(THRESHOLD, proof));
+        assertTrue(ok);
+    }
+
+    function testAllowsMintWhenScoreAboveThresholdAndProofValid() public {
+        bytes memory proof = hex"deadbeef";
+        verifier.accept(USER, 100, proof);
+
+        (uint256[] memory c, uint256[] memory a) = _emptyArrays();
+        bool ok = policy.beforeMintPolicy(USER, GROUP, c, a, _data(100, proof));
+        assertTrue(ok);
+    }
+
+    function testRevertsWhenScoreBelowThreshold() public {
+        bytes memory proof = hex"deadbeef";
+        verifier.accept(USER, 49, proof);
+
+        (uint256[] memory c, uint256[] memory a) = _emptyArrays();
+        vm.expectRevert(abi.encodeWithSelector(ScoreGatedMintPolicy.ScoreBelowThreshold.selector, 49, THRESHOLD));
+        policy.beforeMintPolicy(USER, GROUP, c, a, _data(49, proof));
+    }
+
+    function testRevertsWhenProofDoesNotVerify() public {
+        // Verifier never sees this tuple — verifyScore returns false.
+        bytes memory proof = hex"deadbeef";
+
+        (uint256[] memory c, uint256[] memory a) = _emptyArrays();
+        vm.expectRevert(abi.encodeWithSelector(ScoreGatedMintPolicy.ProofVerificationFailed.selector, USER, 80));
+        policy.beforeMintPolicy(USER, GROUP, c, a, _data(80, proof));
+    }
+
+    function testIgnoresGroupArgument() public {
+        // Same proof works for any group (single-group verifier).
+        bytes memory proof = hex"deadbeef";
+        verifier.accept(USER, 80, proof);
+
+        (uint256[] memory c, uint256[] memory a) = _emptyArrays();
+        assertTrue(policy.beforeMintPolicy(USER, address(0xAAA1), c, a, _data(80, proof)));
+        assertTrue(policy.beforeMintPolicy(USER, address(0xBBB2), c, a, _data(80, proof)));
+    }
+
+    function testImmutablesPersistAfterDeploy() public {
+        assertEq(address(policy.verifier()), address(verifier));
+        assertEq(policy.scoreThreshold(), THRESHOLD);
+    }
+}


### PR DESCRIPTION
## Summary

`ScoreGatedMintPolicy` is the first non-trivial mint policy beyond the always-true `MintPolicy`. It gates `beforeMintPolicy` on an off-chain trust-score check verified through an external SMT verifier (NewMockScore-shaped):

- `_data` is decoded as `(uint256 score, bytes proof)`.
- Requires `score >= scoreThreshold`.
- Requires `IScoreVerifier(verifier).verifyScore(minter, score, proof) == true`.
- The `group` argument is ignored — the current verifier is single-group; a future multi-group verifier would route by `group` inside `verifyScore`.
- Redeem and burn hooks inherit the trivial base behavior.

## Tests

6 cases, all passing in `test/groups/ScoreGatedMintPolicy.t.sol`:

- `testAllowsMintWhenScoreAtThresholdAndProofValid`
- `testAllowsMintWhenScoreAboveThresholdAndProofValid`
- `testRevertsWhenScoreBelowThreshold`
- `testRevertsWhenProofDoesNotVerify`
- `testIgnoresGroupArgument` (load-bearing — encodes the single-group constraint)
- `testImmutablesPersistAfterDeploy`

## Deploying

This repo doesn't use `forge script` for one-off deployments. Use `forge create` directly:

```bash
forge create src/groups/ScoreGatedMintPolicy.sol:ScoreGatedMintPolicy \
    --rpc-url $RPC_URL \
    --private-key $DEPLOYER_KEY \
    --constructor-args $VERIFIER_ADDRESS $SCORE_THRESHOLD
```

Then bind to a Circles group avatar (separate EOA) via `Hub.registerGroup(policyAddress, name, symbol, metadataDigest)`.

## Test plan

- [x] `forge build` clean.
- [x] `forge test --match-contract ScoreGatedMintPolicyTest -vv` — 6/6 pass.
- [x] `forge fmt --check` clean.